### PR TITLE
Fix pointer arithmetic in SdFatUtil

### DIFF
--- a/Firmware/SdFatUtil.cpp
+++ b/Firmware/SdFatUtil.cpp
@@ -40,7 +40,9 @@ extern char __bss_end;
  */
 int SdFatUtil::FreeRam() {
   char top;
-  return __brkval ? &top - __brkval : &top - &__bss_end;
+  return __brkval
+         ? (int)((uintptr_t)&top - (uintptr_t)__brkval)
+         : (int)((uintptr_t)&top - (uintptr_t)&__bss_end);
 }
 #endif  // __arm
 


### PR DESCRIPTION
### **User description**
## Summary
- fix undefined pointer subtraction when computing free RAM

## Testing
- `cmake --build . --target test_run_all`

------
https://chatgpt.com/codex/tasks/task_e_6844723f4094832785a822c9d3f92d8d


___

### **PR Type**
Bug fix


___

### **Description**
- Fix undefined pointer arithmetic in `SdFatUtil::FreeRam`

- Use `uintptr_t` casts for safe pointer subtraction


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SdFatUtil.cpp</strong><dd><code>Fix pointer arithmetic in FreeRam for defined behavior</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Firmware/SdFatUtil.cpp

<li>Replaced direct pointer subtraction with <code>uintptr_t</code> arithmetic<br> <li> Ensured safe and defined calculation of free RAM


</details>


  </td>
  <td><a href="https://github.com/vdidon/Prusa-Firmware/pull/1/files#diff-b4b92866ee65415f5e897d2f727ec02ed32d27b9a6a681f93c8bebce81a7eda4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>