### PR TITLE
Fix rbuf_put overflow check with short lock

### DIFF
--- a/Firmware/rbuf.c
+++ b/Firmware/rbuf.c
@@ -20,17 +20,20 @@ void rbuf_ini(uint8_t* ptr, uint8_t l)
 int rbuf_put(uint8_t* ptr, uint8_t b)
 {
 //#ifdef _NO_ASM
-	_lock();                         //lock
-	uint8_t buf_w = ptr[1];          //get write index
-	uint8_t buf_r = ptr[2];          //get read index
-	_unlock();                       //unlock
-	ptr[4 + buf_w] = b;              //store byte to buffer
-	buf_w++;                         //incerment write index
-	uint8_t buf_l = ptr[0];          //get length
-	if (buf_w >= buf_l) buf_w = 0;   //rotate write index
-	if (buf_w == buf_r) return -1;   //return -1 to signal buffer full
-	ptr[1] = buf_w;                  //store write index
-	return 0;                        //return 0 to signal success
+    _lock();                         //lock
+    uint8_t buf_w = ptr[1];          //get write index
+    uint8_t buf_r = ptr[2];          //get read index
+    uint8_t buf_l = ptr[0];          //get length
+    _unlock();                       //unlock
+
+    uint8_t next_w = buf_w + 1;      //calculate next write index
+    if (next_w >= buf_l) next_w = 0; //rotate write index
+    if (next_w == buf_r)             //buffer full?
+        return -1;                   //return -1 to signal buffer full
+
+    ptr[4 + buf_w] = b;              //store byte to buffer
+    ptr[1] = next_w;                 //store write index
+    return 0;                        //return 0 to signal success
 //#else //_NO_ASM
 // TODO - optimized assembler version
 //	asm("movw r26, r24");


### PR DESCRIPTION
### **User description**
## Summary
- avoid writing to rbuf when full without holding lock longer

## Testing
- `cmake ..`
- `cmake --build . --target test_run_all`


------
https://chatgpt.com/codex/tasks/task_e_68447946ce0c8327a8f5bd8c8523c8ae


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes buffer overflow check in `rbuf_put` to prevent overwriting data.

- Moves buffer full check before writing to buffer for safety.

- Refactors write index calculation for clarity and correctness.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rbuf.c</strong><dd><code>Correct buffer full check and write index update in rbuf_put</code></dd></summary>
<hr>

Firmware/rbuf.c

<li>Reorders logic in <code>rbuf_put</code> to check for buffer full before writing.<br> <li> Calculates next write index and checks for overflow preemptively.<br> <li> Updates write index only after successful write.<br> <li> Improves code clarity and prevents data corruption.


</details>


  </td>
  <td><a href="https://github.com/vdidon/Prusa-Firmware/pull/3/files#diff-8d5863328ad889f4427ea2ac1a71c9d5f98982ef461b816b59f2a82c56a0f49a">+15/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>